### PR TITLE
fix: stop matching instrumental tracks against unrelated songs (#40)

### DIFF
--- a/Jellyfin.Plugin.Lyrics/Configuration/PluginConfiguration.cs
+++ b/Jellyfin.Plugin.Lyrics/Configuration/PluginConfiguration.cs
@@ -50,6 +50,18 @@ public class PluginConfiguration : BasePluginConfiguration
     public int[] BackoffScheduleDays { get; set; } = [1, 3, 7, 30];
 
     /// <summary>
+    /// Gets or sets a value indicating whether to filter LRCLIB matches by track duration.
+    /// </summary>
+    public bool EnableDurationFilter { get; set; } = true;
+
+    /// <summary>
+    /// Gets or sets the duration tolerance in seconds for accepting an LRCLIB match.
+    /// Results whose duration differs from the local track by more than this value are rejected.
+    /// Ignored when <see cref="EnableDurationFilter"/> is false.
+    /// </summary>
+    public int DurationToleranceSeconds { get; set; } = 15;
+
+    /// <summary>
     /// Gets or sets the legacy state cursor value.
     /// </summary>
     public int StateCursor { get; set; }

--- a/Jellyfin.Plugin.Lyrics/Configuration/config.html
+++ b/Jellyfin.Plugin.Lyrics/Configuration/config.html
@@ -25,6 +25,22 @@
                             <span>Exclude album name from the search parameters.</span>
                         </label>
                         <label class="checkboxContainer">
+                            <input is="emby-checkbox" type="checkbox" id="enableDurationFilter" />
+                            <span>Filter matches by song length (recommended)</span>
+                        </label>
+                        <div id="durationFilterSettings" style="margin-left: 2.2em;">
+                            <p style="margin: 0 0 1em 0; font-size: 0.95em; opacity: 0.8;">
+                                Skip lyrics whose song length is too different from your file. Turn this off to accept any match regardless of length.
+                            </p>
+                            <label>
+                                Duration tolerance (seconds)
+                                <input is="emby-input" type="number" id="durationToleranceSeconds" min="1" step="1" />
+                            </label>
+                            <p style="margin: 0 0 1em 0; font-size: 0.95em; opacity: 0.8;">
+                                How close the song length must be to a lyrics match for the match to count. If wrong lyrics show up on instrumental or interlude tracks, lower this value. If lyrics are missing for songs that should have them, raise it. Default: 15.
+                            </p>
+                        </div>
+                        <label class="checkboxContainer">
                             <input is="emby-checkbox" type="checkbox" id="enableAdaptiveRetryBackoff" />
                             <span>Skip repeated misses (recommended)</span>
                         </label>
@@ -81,6 +97,8 @@
 
                     document.querySelector('#excludeArtistName').checked = config.ExcludeArtistName;
                     document.querySelector('#excludeAlbumName').checked = config.ExcludeAlbumName;
+                    document.querySelector('#enableDurationFilter').checked = config.EnableDurationFilter !== false;
+                    document.querySelector('#durationToleranceSeconds').value = Math.max(parseInt(config.DurationToleranceSeconds, 10) || 15, 1);
 
                     document.querySelector('#enableAdaptiveRetryBackoff').checked = config.EnableAdaptiveRetryBackoff !== false;
                     document.querySelector('#enableRunCap').checked = config.EnableRunCap !== false;
@@ -95,6 +113,7 @@
                     LyricsPluginConfiguration.toggleStrictSearchVisibility();
                     LyricsPluginConfiguration.toggleBackoffVisibility();
                     LyricsPluginConfiguration.toggleRunCapVisibility();
+                    LyricsPluginConfiguration.toggleDurationFilterVisibility();
                     Dashboard.hideLoadingMsg();
                 });
             },
@@ -106,6 +125,10 @@
                     config.UseStrictSearch = document.querySelector('#useStrictSearch').checked;
                     config.ExcludeArtistName = document.querySelector('#excludeArtistName').checked;
                     config.ExcludeAlbumName = document.querySelector('#excludeAlbumName').checked;
+
+                    config.EnableDurationFilter = document.querySelector('#enableDurationFilter').checked;
+                    var durationToleranceValue = parseInt(document.querySelector('#durationToleranceSeconds').value || '15', 10);
+                    config.DurationToleranceSeconds = Number.isFinite(durationToleranceValue) ? Math.max(durationToleranceValue, 1) : 15;
                     config.EnableAdaptiveRetryBackoff = document.querySelector('#enableAdaptiveRetryBackoff').checked;
                     config.EnableRunCap = document.querySelector('#enableRunCap').checked;
 
@@ -154,6 +177,15 @@
                 else {
                     document.getElementById('runCapSettings').classList.add('hide');
                 }
+            },
+
+            toggleDurationFilterVisibility: function () {
+                if (document.getElementById('enableDurationFilter').checked) {
+                    document.getElementById('durationFilterSettings').classList.remove('hide');
+                }
+                else {
+                    document.getElementById('durationFilterSettings').classList.add('hide');
+                }
             }
         };
 
@@ -176,6 +208,10 @@
 
         document.getElementById('enableRunCap').addEventListener('change', function () {
             LyricsPluginConfiguration.toggleRunCapVisibility();
+        });
+
+        document.getElementById('enableDurationFilter').addEventListener('change', function () {
+            LyricsPluginConfiguration.toggleDurationFilterVisibility();
         });
         </script>
     </div>

--- a/Jellyfin.Plugin.Lyrics/LyricsProvider.cs
+++ b/Jellyfin.Plugin.Lyrics/LyricsProvider.cs
@@ -80,6 +80,17 @@ public class LyricsProvider : ILyricProvider
 
     private static bool ExcludeAlbumName => LyricsPlugin.Instance?.Configuration.ExcludeAlbumName ?? false;
 
+    private static bool EnableDurationFilter => LyricsPlugin.Instance?.Configuration.EnableDurationFilter ?? true;
+
+    private static int DurationToleranceSeconds
+    {
+        get
+        {
+            var configured = LyricsPlugin.Instance?.Configuration.DurationToleranceSeconds ?? 15;
+            return configured > 0 ? configured : 15;
+        }
+    }
+
     /// <inheritdoc />
     public string Name => LyricsPlugin.Instance!.Name;
 
@@ -242,6 +253,63 @@ public class LyricsProvider : ILyricProvider
             || string.Equals(suffix, PlainSuffix, StringComparison.OrdinalIgnoreCase);
     }
 
+    // Reject results whose duration or artist is incompatible with the request, so a track named
+    // "Faded (Interlude)" can't be matched against an unrelated song with the same title.
+    private bool IsAcceptableMatch(LyricSearchRequest request, LyricsSearchResponse response)
+    {
+        // Tolerance accounts for trailing silence, LAME encoder padding, vinyl-rip fade-outs, and
+        // minor master/remaster differences. The artist check above does the heavy lifting; this
+        // is just a sanity net so a 30-second interlude can't get matched to a 4-minute pop song.
+        if (EnableDurationFilter && request.Duration is not null && response.Duration is not null)
+        {
+            var tolerance = DurationToleranceSeconds;
+            var requestSeconds = TimeSpan.FromTicks(request.Duration.Value).TotalSeconds;
+            var responseSeconds = response.Duration.Value;
+            if (Math.Abs(requestSeconds - responseSeconds) > tolerance)
+            {
+                _logger.LogDebug(
+                    "Rejected LRCLIB match {Id}: duration mismatch (req {Requested:F0}s, got {Got:F0}s)",
+                    response.Id,
+                    requestSeconds,
+                    responseSeconds);
+                return false;
+            }
+        }
+
+        if (request.ArtistNames is { Count: > 0 } && !string.IsNullOrEmpty(response.ArtistName))
+        {
+            var matched = false;
+            foreach (var requested in request.ArtistNames)
+            {
+                foreach (var token in SplitArtists(requested))
+                {
+                    if (response.ArtistName.Contains(token, StringComparison.OrdinalIgnoreCase))
+                    {
+                        matched = true;
+                        break;
+                    }
+                }
+
+                if (matched)
+                {
+                    break;
+                }
+            }
+
+            if (!matched)
+            {
+                _logger.LogDebug(
+                    "Rejected LRCLIB match {Id}: artist mismatch (requested {Requested}, got {Got})",
+                    response.Id,
+                    request.ArtistNames,
+                    response.ArtistName);
+                return false;
+            }
+        }
+
+        return true;
+    }
+
     private async Task<IEnumerable<RemoteLyricInfo>> GetExactMatch(
         LyricSearchRequest request,
         CancellationToken cancellationToken)
@@ -302,6 +370,11 @@ public class LyricsProvider : ILyricProvider
             return Enumerable.Empty<RemoteLyricInfo>();
         }
 
+        if (!IsAcceptableMatch(request, response))
+        {
+            return Enumerable.Empty<RemoteLyricInfo>();
+        }
+
         return GetRemoteLyrics(response);
     }
 
@@ -324,7 +397,7 @@ public class LyricsProvider : ILyricProvider
         // Try each artist variant (full combined name first, then individual artists).
         foreach (var artist in artists)
         {
-            var results = await SearchLrclib(trackName, artist, albumName, cancellationToken).ConfigureAwait(false);
+            var results = await SearchLrclib(request, trackName, artist, albumName, cancellationToken).ConfigureAwait(false);
             if (results.Count > 0)
             {
                 return results.OrderByDescending(x => x.Metadata.IsSynced);
@@ -334,7 +407,7 @@ public class LyricsProvider : ILyricProvider
             if (!string.IsNullOrEmpty(albumName))
             {
                 _logger.LogDebug("No results with album for artist {Artist}, retrying without album for {Track}", artist, trackName);
-                results = await SearchLrclib(trackName, artist, null, cancellationToken).ConfigureAwait(false);
+                results = await SearchLrclib(request, trackName, artist, null, cancellationToken).ConfigureAwait(false);
                 if (results.Count > 0)
                 {
                     return results.OrderByDescending(x => x.Metadata.IsSynced);
@@ -342,20 +415,12 @@ public class LyricsProvider : ILyricProvider
             }
         }
 
-        // Final fallback: try with just track name (no artist, no album).
-        if (artists.Count > 0)
+        // Track-name-only fallback only when no artist info exists at all.
+        // When the user has artists, a track-name-only search would let "Faded (Interlude)"
+        // match any "Faded" by any artist — exactly the bug we're trying to prevent.
+        if (artists.Count == 0)
         {
-            _logger.LogDebug("No results with any artist, retrying with only track name for {Track}", trackName);
-            var fallbackResults = await SearchLrclib(trackName, null, null, cancellationToken).ConfigureAwait(false);
-            if (fallbackResults.Count > 0)
-            {
-                return fallbackResults.OrderByDescending(x => x.Metadata.IsSynced);
-            }
-        }
-        else
-        {
-            // No artist info at all — search by track name only.
-            var results = await SearchLrclib(trackName, null, albumName, cancellationToken).ConfigureAwait(false);
+            var results = await SearchLrclib(request, trackName, null, albumName, cancellationToken).ConfigureAwait(false);
             if (results.Count > 0)
             {
                 return results.OrderByDescending(x => x.Metadata.IsSynced);
@@ -363,7 +428,7 @@ public class LyricsProvider : ILyricProvider
 
             if (!string.IsNullOrEmpty(albumName))
             {
-                results = await SearchLrclib(trackName, null, null, cancellationToken).ConfigureAwait(false);
+                results = await SearchLrclib(request, trackName, null, null, cancellationToken).ConfigureAwait(false);
                 if (results.Count > 0)
                 {
                     return results.OrderByDescending(x => x.Metadata.IsSynced);
@@ -375,6 +440,7 @@ public class LyricsProvider : ILyricProvider
     }
 
     private async Task<List<RemoteLyricInfo>> SearchLrclib(
+        LyricSearchRequest request,
         string trackName,
         string? artistName,
         string? albumName,
@@ -417,6 +483,11 @@ public class LyricsProvider : ILyricProvider
         var results = new List<RemoteLyricInfo>();
         foreach (var item in response)
         {
+            if (!IsAcceptableMatch(request, item))
+            {
+                continue;
+            }
+
             results.AddRange(GetRemoteLyrics(item));
         }
 
@@ -426,6 +497,12 @@ public class LyricsProvider : ILyricProvider
     private List<RemoteLyricInfo> GetRemoteLyrics(LyricsSearchResponse response)
     {
         var results = new List<RemoteLyricInfo>();
+
+        if (response.Instrumental == true)
+        {
+            _logger.LogDebug("Skipping LRCLIB entry {Id} flagged as instrumental", response.Id);
+            return results;
+        }
 
         if (!string.IsNullOrEmpty(response.SyncedLyrics))
         {

--- a/README.md
+++ b/README.md
@@ -45,11 +45,28 @@ Looking for **v10.10.7 support**? -> https://github.com/Felitendo/jellyfin-plugi
 - **Missing lyrics for specific tracks?**  
   → Manually refresh metadata (see below)
   → Toggle the `"Use strict search."` option in plugin settings
+  → If a song with very long trailing silence or a remastered version is being skipped, increase `Duration tolerance (seconds)`
+
+- **Wrong lyrics on instrumental / interlude tracks?**  
+  → The plugin filters matches by artist and by duration. If you still see wrong matches, **lower** `Duration tolerance (seconds)` (e.g. `5`) so only very close-duration matches are accepted.
+  → If legitimate songs are being skipped instead, **raise** the value (e.g. `30`).
 
 - **Scheduled task takes too long?**  
   → Turn on `Skip repeated misses` (default on)
   → Turn on `Limit work per run` and reduce `Max songs to check each run`
   → Keep `Retry after days` on `1,3,7,30` unless you want faster/slower retries
+
+### How match filtering works
+
+- **Filter matches by song length** — default on  
+  When on, the plugin compares your local song's length to the length of the lyrics it finds online and skips lyrics whose length is too different. This stops short tracks like intros and interludes from getting lyrics that belong to a completely different song with a similar title.  
+  Turn this off if you want the plugin to accept any match regardless of length (not recommended — you'll get more wrong matches).
+
+- **Duration tolerance (seconds)** — default `15`  
+  Only used when the length filter is on. How close the song length has to be to a lyrics match for the match to count. If they differ by more than this many seconds, the lyrics are skipped.
+  - **Lower** (e.g. `5`) — stricter. Better at catching wrong matches, but might skip correct lyrics if your file has long silence at the end or is a different version (remaster, vinyl rip).
+  - **Higher** (e.g. `30`) — more forgiving. Accepts more correct matches, but lets more wrong ones through.
+  - The artist always has to match too — this setting only controls the length check.
 
 ### How the speed settings work
 


### PR DESCRIPTION
## Summary

Fixes [#40](https://github.com/Felitendo/jellyfin-plugin-lyrics/issues/40) — instrumental/interlude tracks being assigned lyrics from a completely different song that happens to share a similar title.

Three layered changes in `LyricsProvider.cs`, plus a user-facing toggle:

- **Honor LRCLIB's `instrumental: true` flag.** It was already being deserialized in `LyricsSearchResponse` but never read. `GetRemoteLyrics` now early-returns empty when the flag is set, so LRCLIB-known instrumentals stop producing matches.
- **Validate every match against the request.** New `IsAcceptableMatch` helper rejects results whose artist doesn't appear (case-insensitive substring against any token from `SplitArtists`) or whose duration differs from the local file by more than the configured tolerance. Applied in both `GetExactMatch` (single response from `/api/get`) and `SearchLrclib` (per-item filter on `/api/search` results).
- **Drop the dangerous track-name-only fuzzy fallback when artist info exists.** Previously, if artist+album and artist-only both failed, the code would fall back to `SearchLrclib(trackName, null, null)` — which is exactly how "Faded (Interlude)" by Alan Walker ended up matching a "Faded" by some other artist. The fallback is preserved only when no artist info is available at all.

## New setting

- **Filter matches by song length** (checkbox, default on) — turn the duration filter off entirely if needed.
- **Duration tolerance (seconds)** (default 15) — only used when the filter is on. Lower for stricter matching, higher for more forgiving (long trailing silence, remasters, vinyl rips).

Existing users get the filter on by default after update — the bug is fixed out-of-the-box without any settings change.

## Test plan

- [x] `dotnet build` clean (0 warnings, 0 errors)
- [x] Plugin loads in Jellyfin (verified in local container)
- [ ] Manual reproduction: track titled "Faded (Interlude)" by Alan Walker (~30s) no longer gets matched
- [ ] Regression check: legitimate songs (full-length "Faded" by Alan Walker) still match
- [ ] Tolerance edge cases: a track with ~10s trailing silence still matches at default 15s tolerance
- [ ] Filter off: matches behave like before the fix (artist check still applies)

## Notes for reviewers

- No new HTTP calls or external dependencies — purely client-side filtering of existing LRCLIB responses.
- New debug log lines (`Rejected LRCLIB match {Id}: artist mismatch …` / `… duration mismatch …` / `Skipping LRCLIB entry … flagged as instrumental`) make it easy to confirm the fix is working in the wild.
- README has a new "How match filtering works" section explaining both the toggle and the tolerance value, plus two new troubleshooting entries.